### PR TITLE
Fix: Dynamic Grid resizing for custom values

### DIFF
--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -1287,7 +1287,18 @@ public class Launcher extends Activity
     public void setDynamicGridSize(DeviceProfile.GridSize size) {
         int gridSize = SettingsProvider.getIntCustomDefault(this,
                 SettingsProvider.SETTINGS_UI_DYNAMIC_GRID_SIZE, 0);
-        if (gridSize != size.getValue()) {
+        boolean customValuesChanged = false;
+        if (gridSize == size.getValue() && size == DeviceProfile.GridSize.Custom) {
+            int tempRows = SettingsProvider.getIntCustomDefault(this,
+                    SettingsProvider.SETTINGS_UI_HOMESCREEN_ROWS, (int)mGrid.numRows);
+            int tempColumns = SettingsProvider.getIntCustomDefault(this,
+                    SettingsProvider.SETTINGS_UI_HOMESCREEN_COLUMNS, (int)mGrid.numColumns);
+            if (tempColumns != (int) mGrid.numColumns || tempRows != (int) mGrid.numRows) {
+                customValuesChanged = true;
+            }
+        }
+
+        if (gridSize != size.getValue() || customValuesChanged) {
             SettingsProvider.putInt(this,
                     SettingsProvider.SETTINGS_UI_DYNAMIC_GRID_SIZE, size.getValue());
 


### PR DESCRIPTION
Update the grid when the custom values are changed

Repro:
 - Set custom grid to 7x7
 - press home and observe grid is updated to 7x7
 - Set custom grid to 2x3
 - press home and observe that the grid isn't updated

Change-Id: I8284eff08a96992b01b406ec1bff61f38d0ca683